### PR TITLE
ContainerBox and units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -500,3 +500,4 @@ $RECYCLE.BIN/
 # Vim temporary swap files
 *.swp
 
+/.vscode

--- a/SConstruct
+++ b/SConstruct
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import os
 
 env = SConscript("./extern/godot-cpp/SConstruct")
 
@@ -10,11 +11,20 @@ env = SConscript("./extern/godot-cpp/SConstruct")
 # - CPPDEFINES are for pre-processor defines
 # - LINKFLAGS are for linking flags
 
-# tweak this if you want to use different folders, or more folders, to store your source code in.
-env.Append(CPPPATH=['include/'])
-sources = Glob("src/*.cpp")
+# collects all .cpp files except "gen"
+cpp_files = []
+exclude = set(['src\\gen',])
+for root, dirs, files in os.walk('src'):
+    dirs[:] = [d for d in dirs if os.path.join(root, d) not in exclude]
+    for file in files:
+        if file.endswith('.cpp'):
+            cpp_files.append(os.path.join(root, file))
+
+env.Append(CPPPATH=['./include/', './src/'])
+sources = cpp_files
 
 if env["target"] in ["editor", "template_debug"]:
+    # Will create issues if you create more directories in doc_classes/
     doc_data = env.GodotCPPDocData("src/gen/doc_data.gen.cpp", source=Glob("doc_classes/*.xml"))
     sources.append(doc_data)
 

--- a/include/commons/container_unit_converter.h
+++ b/include/commons/container_unit_converter.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "commons/unit_converter.h"
+#include "core/units/unit.h"
+
+/// @brief A wrapper unit converter for easy use in containers.
+class ContainerUnitConverter : UnitConverter
+{
+public:
+    ContainerUnitConverter();
+    ~ContainerUnitConverter();
+    
+    /// @brief Gets width in any unit type from any correct length pair.
+    /// @param pair Length and unit
+    /// @param parent_width Width of the parent container
+    /// @param window_size Root viewport size
+    /// @param unit_type Type of the returning width from Length::Unit (default PIXEL)
+    /// @return Width in the provided unit type
+    static double get_width(LengthPair pair, double parent_width, Vector2i window_size, int unit_type = LengthUnit::PIXEL);
+    
+    /// @brief Gets width in pixels from any correct length pair.
+    /// @param pair Length and unit
+    /// @param parent_width Width of the parent container
+    /// @param window_size Root viewport size
+    /// @return Width in pixels
+    static double get_width_px(LengthPair pair, double parent_width, Vector2i window_size);
+
+    /// @brief Gets width in vw (viewport width) from any correct length pair.
+    /// @param pair Length and unit
+    /// @param parent_width Width of the parent container
+    /// @param window_size Root viewport size
+    /// @return Width in vw
+    static double get_width_vw(LengthPair pair, double parent_width, Vector2i window_size);
+
+    /// @brief Gets width in vh (viewport height) from any correct length pair.
+    /// @param pair Length and unit
+    /// @param parent_width Width of the parent container
+    /// @param window_size Root viewport size
+    /// @return Width in vh
+    static double get_width_vh(LengthPair pair, double parent_width, Vector2i window_size);
+
+    /// @brief Gets width in % (percentage) from any correct length pair.
+    /// @param pair Length and unit
+    /// @param parent_width Width of the parent container
+    /// @param window_size Root viewport size
+    /// @return Width in %/pct
+    static double get_width_percentage(LengthPair pair, double parent_width, Vector2i window_size);
+    
+    /// @brief Gets height in any unit type from any correct length pair.
+    /// @param pair Length and unit
+    /// @param parent_height Height of the parent container
+    /// @param window_size Root viewport size
+    /// @param unit_type Type of the returning height from Length::Unit (default PIXEL)
+    /// @return height in the provided unit type
+    static double get_height(LengthPair pair, double parent_height, Vector2i window_size, int unit_type = LengthUnit::PIXEL);
+    
+    /// @brief Gets height in pixels from any correct length pair.
+    /// @param pair Length and unit
+    /// @param parent_height Height of the parent container
+    /// @param window_size Root viewport size
+    /// @return Height in pixels
+    static double get_height_px(LengthPair pair, double parent_height, Vector2i window_size);
+
+    /// @brief Gets height in vw (viewport height) from any correct length pair.
+    /// @param pair Length and unit
+    /// @param parent_height Height of the parent container
+    /// @param window_size Root viewport size
+    /// @return Height in vw
+    static double get_height_vw(LengthPair pair, double parent_height, Vector2i window_size);
+
+    /// @brief Gets height in vh (viewport height) from any correct length pair.
+    /// @param pair Length and unit
+    /// @param parent_height Height of the parent container
+    /// @param window_size Root viewport size
+    /// @return Height in vh
+    static double get_height_vh(LengthPair pair, double parent_height, Vector2i window_size);
+
+    /// @brief Gets height in % (percentage) from any correct length pair.
+    /// @param pair Length and unit
+    /// @param parent_height Height of the parent container
+    /// @param window_size Root viewport size
+    /// @return Height in %/pct
+    static double get_height_percentage(LengthPair pair, double parent_height, Vector2i window_size);
+};

--- a/include/commons/string_helper.h
+++ b/include/commons/string_helper.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <godot_cpp/godot.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+using namespace godot;
+
+/// @brief Replaces all instances of a string inside of another string to another string.
+/// @param str Original string with all instances
+/// @param replace String instances to replace
+/// @param to String to replace string instances with
+/// @return String with replaced strings to another string
+String replace(String str, String replace, String to);

--- a/include/commons/unit_converter.h
+++ b/include/commons/unit_converter.h
@@ -1,0 +1,133 @@
+#pragma once
+
+/// @brief A converter class for different unit types (pixel, percentage, viewport width, viewport height)
+class UnitConverter
+{  
+public:
+    UnitConverter() = default;
+    ~UnitConverter() = default;
+    static double px_to_percentage(double px, double base);
+    static double px_to_vw(double px, double width);
+    static double px_to_vh(double px, double height);
+    static double vw_to_percentage(double vw, double window_width, double pct_base);
+    static double vw_to_px(double vw, double width);
+    static double vw_to_vh(double vw, double width, double height);
+    static double vh_to_percentage(double vh, double window_height, double pct_base);
+    static double vh_to_px(double vh, double height);
+    static double vh_to_vw(double vh, double width, double height);
+    static double percentage_to_vw(double percentage, double window_width, double pct_base);
+    static double percentage_to_px(double percentage, double base);
+    static double percentage_to_vh(double percentage, double window_height, double pct_base);
+};
+
+/// @brief pixel to percentage
+/// @param px value
+/// @param base base from which percentage should be calculated. (ex. container width)
+/// @return percentage (format: 0.5 (written: 50%) (not 50))
+inline double UnitConverter::px_to_percentage(double px, double base)
+{
+    return px/base;
+}
+
+/// @brief pixel value to vw value
+/// @param px value
+/// @param width width of the viewport
+/// @return vw value (format: 50 (not 0.5))
+inline double UnitConverter::px_to_vw(double px, double width)
+{
+    return px/width * 100;
+}
+
+/// @brief pixel value to vh value
+/// @param px value
+/// @param height height of the viewport
+/// @return vh value (format: 50 (not 0.5))
+inline double UnitConverter::px_to_vh(double px, double height)
+{
+    return px/height * 100;
+}
+
+/// @brief vw value to percentage value
+/// @param vw value
+/// @param window_width Viewport width
+/// @param pct_base width from which percentage is calculated (ex. parent container)
+/// @return percentage value from the pct_base
+inline double UnitConverter::vw_to_percentage(double vw, double window_width, double pct_base)
+{
+    return vw/100 * window_width/pct_base;
+}
+
+/// @brief vw value to pixel value
+/// @param vw value
+/// @param width viewport width value
+/// @return pixel value
+inline double UnitConverter::vw_to_px(double vw, double width)
+{
+    return vw/100*width;
+}
+
+/// @brief vw value to vh value
+/// @param vw value
+/// @param width viewport width
+/// @param height viewport height
+/// @return vh value
+inline double UnitConverter::vw_to_vh(double vw, double width, double height){
+    return ((vw * width / 100) / height) * 100;
+}
+
+/// @brief vh value to percentage value
+/// @param vh value
+/// @param window_height Viewport height
+/// @param pct_base height from which percentage is calculated (ex. parent container)
+/// @return percentage value from the pct_base
+inline double UnitConverter::vh_to_percentage(double vh, double window_height, double pct_base)
+{
+    return vh/100 * window_height/pct_base;
+}
+
+/// @brief vh value to pixel value
+/// @param vh value
+/// @param height viewport height
+/// @return pixel value
+inline double UnitConverter::vh_to_px(double vh, double height)
+{
+    return vh/100*height;
+}
+
+/// @brief vh value to vw value
+/// @param vh value
+/// @param width viewport width
+/// @param height viewport height
+/// @return vw value
+inline double UnitConverter::vh_to_vw(double vh, double width, double height){
+    return ((vh * height / 100) / width) * 100;
+}
+
+/// @brief percentage value to vw value
+/// @param percentage value
+/// @param window_width viewport width
+/// @param pct_base width from which percentage was calculated (ex. parent container)
+/// @return percentage value
+inline double UnitConverter::percentage_to_vw(double percentage, double window_width, double pct_base)
+{
+    return (pct_base*percentage)/window_width*100;
+}
+
+/// @brief percentage value to px value
+/// @param percentage value
+/// @param base base from which the percentage was calculated.
+/// @return percentage value
+inline double UnitConverter::percentage_to_px(double percentage, double base)
+{
+    return base*percentage;
+}
+
+/// @brief percentage value to vh value
+/// @param percentage value
+/// @param window_height viewport height
+/// @param pct_base height from which percentage was calculated.
+/// @return percentage value
+inline double UnitConverter::percentage_to_vh(double percentage, double window_height, double pct_base)
+{
+     return (pct_base*percentage)/window_height*100;
+}

--- a/include/containers/container_box.h
+++ b/include/containers/container_box.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <godot_cpp/godot.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/classes/control.hpp>
+#include "commons/container_unit_converter.h"
+
+using namespace godot;
+
+/// @brief Container class for all HarmoniaUI containers
+class ContainerBox : public Control
+{
+    GDCLASS(ContainerBox, Control);
+
+public:
+    ContainerBox() = default;
+    ~ContainerBox() = default;
+    double update_time = 0;
+    double update_interval = 1.0;
+    void ContainerBox::_ready();
+    void ContainerBox::_process(double delta);
+
+    /// @brief Updates the container presentation/view in runtime
+    virtual void update_presentation();
+    
+    /// @brief [EDITOR] Updates the container presentation/view in editor
+    virtual void editor_update_presentation();
+
+    ContainerBox* parent = nullptr;
+
+    /// @brief Should debug outputs be printed to the console?
+    bool debug_outputs = false;
+    
+    /// @brief Sets debug outputs
+    /// @param debug_outputs Should debug outputs be printed?
+    void set_debug_outputs(bool debug_outputs);
+
+    /// @brief Gets the debug outputs setting
+    /// @return debug outputs option
+    bool get_debug_outputs();
+
+
+    LengthPair width; /* Width pair, stores length and unit */
+
+    /// @brief Gets the width in provided unit
+    /// @param unit_type Width unit type
+    /// @return Width in the provided unit type
+    double get_width(int unit_type = LengthUnit::PIXEL);
+
+    /// @brief Sets the width to provided length and unit
+    /// @param length Width length
+    /// @param unit_type Width length unit type 
+    void set_width(double length, int unit_type = LengthUnit::PIXEL);
+
+    /// @brief An editor way of getting width, don't use runtime
+    /// @param unit_type Width unit type
+    /// @return Width in provided unit type
+    double editor_get_width(int unit_type = LengthUnit::PIXEL);
+
+    /// @brief Gets current width pair in a string representation
+    /// @return Width string representation
+    String get_width_str();
+
+    /// @brief Sets width from a string representation of width length pair 
+    /// @param length_and_unit string representataion of width length pair
+    void set_width_str(String length_and_unit);
+    String width_str; /* String representation of width */
+    
+    LengthPair height; /* Height pair, stores length and unit */
+
+    /// @brief Gets the height in provided unit
+    /// @param unit_type height unit type
+    /// @return Height in the provided unit type
+    double get_height(int unit_type = LengthUnit::PIXEL);
+
+    /// @brief Sets the height to provided length and unit
+    /// @param length Height length
+    /// @param unit_type Height length unit type 
+    void set_height(double length, int unit_type = LengthUnit::PIXEL);
+
+    /// @brief An editor way of getting height, don't use runtime
+    /// @param unit_type Height unit type
+    /// @return Height in provided unit type
+    double editor_get_height(int unit_type = LengthUnit::PIXEL);
+    
+    /// @brief Gets current height pair in a string representation
+    /// @return Height string representation
+    String get_height_str();
+
+    /// @brief Sets height from a string representation of height length pair 
+    /// @param length_and_unit string representataion of height length pair
+    void set_height_str(String length_and_unit);
+    String height_str; /* String representation of height */
+protected:
+    static void _bind_methods();
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+    void _get_property_list(List<PropertyInfo> *p_list) const;
+};

--- a/include/core/units/unit.h
+++ b/include/core/units/unit.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <godot_cpp/godot.hpp>
+#include <godot_cpp/classes/ref_counted.hpp>
+
+using namespace godot;
+
+/// @brief Class for length unit related constants and other unit helper methods
+class LengthUnit : public RefCounted 
+{
+    GDCLASS(LengthUnit, RefCounted);
+private:
+    
+public:
+    LengthUnit() = default;
+    ~LengthUnit() = default;
+    static const int NOT_SET = -1;
+    static const int PIXEL = 0;
+    static const int PERCENTAGE = 1;
+    static const int VIEWPORT_WIDTH = 2;
+    static const int VIEWPORT_HEIGHT = 3;
+protected:
+    static void _bind_methods();
+};
+
+inline void LengthUnit::_bind_methods()
+{
+    BIND_CONSTANT(NOT_SET);
+    BIND_CONSTANT(PIXEL);
+    BIND_CONSTANT(PERCENTAGE);
+    BIND_CONSTANT(VIEWPORT_WIDTH);
+    BIND_CONSTANT(VIEWPORT_HEIGHT);
+}
+
+/// @brief Pair of unit type (from LengthUnit contants) and length
+struct LengthPair{
+    int unit_type;
+    double length;
+    LengthPair(int unit_type, double length);
+    LengthPair() = default;
+
+    /// @brief Gets a length pair from a string representation of that pair
+    /// @param string_pair The string pair representation
+    /// @return Converted length pair
+    static LengthPair get_pair(String string_pair);
+
+    /// @brief Gets a int unit from provided string unit representation;
+    /// @param unit_string String unit representation
+    /// @return Converted int unit
+    static int get_unit(String unit_string);
+
+    /// @brief Gets a string representation of length pair
+    /// @param pair The pair length to convert
+    /// @return Converted string pair
+    static String get_pair_str(LengthPair pair);
+};

--- a/include/register_types.h
+++ b/include/register_types.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <godot_cpp/core/class_db.hpp>
+
 using namespace godot;
 
 void initialize_harmonia(ModuleInitializationLevel p_level);

--- a/src/commons/container_unit_converter.cpp
+++ b/src/commons/container_unit_converter.cpp
@@ -1,0 +1,143 @@
+#include "commons/container_unit_converter.h"
+#include "core/units/unit.h"
+
+double ContainerUnitConverter::get_width(LengthPair pair, double parent_width, Vector2i window_size, int unit_type)
+{
+    if(unit_type == LengthUnit::PIXEL){
+        return get_width_px(pair, parent_width, window_size);
+    }else if(unit_type == LengthUnit::PERCENTAGE){
+        return get_width_percentage(pair, parent_width, window_size);
+    }else if(unit_type == LengthUnit::VIEWPORT_WIDTH){
+        return get_width_vw(pair, parent_width, window_size);
+    }else if(unit_type == LengthUnit::VIEWPORT_HEIGHT){
+        return get_width_vh(pair, parent_width, window_size);
+    }else{
+        return NULL;
+    }
+}
+
+double ContainerUnitConverter::get_width_px(LengthPair pair, double parent_width, Vector2i window_size){
+    if(pair.unit_type == LengthUnit::PIXEL){
+        return pair.length;
+    }else if(pair.unit_type == LengthUnit::PERCENTAGE){
+        return percentage_to_px(pair.length, parent_width);
+    }else if(pair.unit_type == LengthUnit::VIEWPORT_WIDTH){
+        return vw_to_px(pair.length, window_size.x);
+    }else if(pair.unit_type == LengthUnit::VIEWPORT_HEIGHT){
+        return vh_to_px(pair.length, window_size.y);
+    }else{
+        return NULL;
+    }
+}
+
+double ContainerUnitConverter::get_width_vw(LengthPair pair, double parent_width, Vector2i window_size){
+    if(pair.unit_type == LengthUnit::PIXEL){
+        return px_to_vw(pair.length, window_size.x);
+    }else if(pair.unit_type == LengthUnit::PERCENTAGE){
+        return percentage_to_vw(pair.length, window_size.x, parent_width);
+    } else if(pair.unit_type == LengthUnit::VIEWPORT_WIDTH){
+        return pair.length;
+    }else if(pair.unit_type == LengthUnit::VIEWPORT_HEIGHT){
+        return vh_to_vw(pair.length, window_size.x, window_size.y);
+    }else{
+        return NULL;
+    }
+}
+
+double ContainerUnitConverter::get_width_vh(LengthPair pair, double parent_width, Vector2i window_size){
+    if(pair.unit_type == LengthUnit::PIXEL){
+        return px_to_vh(pair.length, window_size.y);
+    }else if(pair.unit_type == LengthUnit::PERCENTAGE){
+        return percentage_to_vh(pair.length, window_size.y, parent_width);
+    }else if(pair.unit_type == LengthUnit::VIEWPORT_WIDTH){
+        return vw_to_vh(pair.length, window_size.x, window_size.y);
+    }else if(pair.unit_type == LengthUnit::VIEWPORT_HEIGHT){
+        return pair.length;
+    }else{
+        return NULL;
+    }
+}
+
+double ContainerUnitConverter::get_width_percentage(LengthPair pair, double parent_width, Vector2i window_size){
+    if(pair.unit_type == LengthUnit::PIXEL){
+        return px_to_percentage(pair.length, parent_width);
+    }else if(pair.unit_type == LengthUnit::PERCENTAGE){
+        return pair.length;
+    }else if(pair.unit_type == LengthUnit::VIEWPORT_WIDTH){
+        return vw_to_percentage(pair.length, window_size.x, parent_width);
+    }else if(pair.unit_type == LengthUnit::VIEWPORT_HEIGHT){
+        return vh_to_percentage(pair.length, window_size.y, parent_width);
+    }else{
+        return NULL;
+    }
+}
+
+double ContainerUnitConverter::get_height(LengthPair pair, double parent_height, Vector2i window_size, int unit_type){
+    if(unit_type == LengthUnit::PIXEL){
+        return get_height_px(pair, parent_height, window_size);
+    }else if(unit_type == LengthUnit::PERCENTAGE){
+        return get_height_percentage(pair, parent_height, window_size);
+    }else if(unit_type == LengthUnit::VIEWPORT_WIDTH){
+        return get_height_vw(pair, parent_height, window_size);
+    }else if(unit_type == LengthUnit::VIEWPORT_HEIGHT){
+        return get_height_vh(pair, parent_height, window_size);
+    }else{
+        return NULL;
+    }
+}
+
+double ContainerUnitConverter::get_height_px(LengthPair pair, double parent_height, Vector2i window_size){
+    if(pair.unit_type == LengthUnit::PIXEL){
+        return pair.length;
+    }else if(pair.unit_type == LengthUnit::PERCENTAGE){
+        return percentage_to_px(pair.length, parent_height);
+    }else if(pair.unit_type == LengthUnit::VIEWPORT_WIDTH){
+        return vw_to_px(pair.length, window_size.x);
+    }else if(pair.unit_type == LengthUnit::VIEWPORT_HEIGHT){
+        return vh_to_px(pair.length, window_size.y);
+    }else{
+        return NULL;
+    }
+}
+
+double ContainerUnitConverter::get_height_vw(LengthPair pair, double parent_height, Vector2i window_size){
+    if(pair.unit_type == LengthUnit::PIXEL){
+        return px_to_vw(pair.length, window_size.x);
+    }else if(pair.unit_type == LengthUnit::PERCENTAGE){
+        return percentage_to_vw(pair.length, window_size.x, parent_height);
+    } else if(pair.unit_type == LengthUnit::VIEWPORT_WIDTH){
+        return pair.length;
+    }else if(pair.unit_type == LengthUnit::VIEWPORT_HEIGHT){
+        return vh_to_vw(pair.length, window_size.x, window_size.y);
+    }else{
+        return NULL;
+    }
+}
+
+double ContainerUnitConverter::get_height_vh(LengthPair pair, double parent_height, Vector2i window_size){
+    if(pair.unit_type == LengthUnit::PIXEL){
+        return px_to_vh(pair.length, window_size.y);
+    }else if(pair.unit_type == LengthUnit::PERCENTAGE){
+        return percentage_to_vh(pair.length, window_size.y, parent_height);
+    }else if(pair.unit_type == LengthUnit::VIEWPORT_WIDTH){
+        return vw_to_vh(pair.length, window_size.x, window_size.y);
+    }else if(pair.unit_type == LengthUnit::VIEWPORT_HEIGHT){
+        return pair.length;
+    }else{
+        return NULL;
+    }
+}
+
+double ContainerUnitConverter::get_height_percentage(LengthPair pair, double parent_height, Vector2i window_size){
+    if(pair.unit_type == LengthUnit::PIXEL){
+        return px_to_percentage(pair.length, parent_height);
+    }else if(pair.unit_type == LengthUnit::PERCENTAGE){
+        return pair.length;
+    }else if(pair.unit_type == LengthUnit::VIEWPORT_WIDTH){
+        return vw_to_percentage(pair.length, window_size.x, parent_height);
+    }else if(pair.unit_type == LengthUnit::VIEWPORT_HEIGHT){
+        return vh_to_percentage(pair.length, window_size.y, parent_height);
+    }else{
+        return NULL;
+    }
+}

--- a/src/commons/string_helper.cpp
+++ b/src/commons/string_helper.cpp
@@ -1,0 +1,39 @@
+#include "commons/string_helper.h"
+
+String replace(String str, String replace, String to){
+    String result;
+    unsigned int str_length = str.length();
+    unsigned int replace_length = replace.length();
+    unsigned int index = 0;
+    for (unsigned int i = 0; i < str_length; i++)
+    {   
+        if(index > 0){
+            index -= 1;
+            continue;
+        }
+
+        for (size_t o = 0; o < replace_length; o++)
+        {
+            if(str_length - i >= replace_length){
+                if(str[i+index] == replace[o]){
+                    index += 1;           
+                }else{
+                    index = 0;
+                    break;
+                }
+            }else{
+                index = 0;
+                break;
+            }
+        }
+        
+        if(index > 0){
+            index -= 1;
+            result += to;
+            continue;
+        }else{
+            result += str[i];
+        }
+    }
+    return result;
+}

--- a/src/containers/container_box.cpp
+++ b/src/containers/container_box.cpp
@@ -1,0 +1,191 @@
+#include "containers/container_box.h"
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+#include <godot_cpp/classes/scene_tree.hpp>
+#include <godot_cpp/classes/window.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
+
+void ContainerBox::_ready(){
+    set_process(true);
+}
+
+void ContainerBox::_process(double time) {
+    update_time += time;
+    if(update_time >= update_interval){
+        bool is_editor = Engine::get_singleton()->is_editor_hint();
+        if (Engine::get_singleton()->is_editor_hint()) {
+            editor_update_presentation();
+        }
+        else {
+            update_presentation();
+        }
+        update_time -= update_interval;
+    }
+}
+
+void ContainerBox::update_presentation(){
+    // Updates self size
+    Vector2 new_size = Vector2(get_width(), get_height());
+    ContainerBox::set_size(new_size);
+}
+
+void ContainerBox::editor_update_presentation(){
+    // Updates self size
+    Vector2 new_size = Vector2(editor_get_width(), editor_get_height());
+    ContainerBox::set_size(new_size);
+}
+
+void ContainerBox::set_debug_outputs(bool debug_outputs)
+{
+    ContainerBox::debug_outputs = debug_outputs;
+}
+
+bool ContainerBox::get_debug_outputs()
+{
+    return ContainerBox::debug_outputs;
+}
+
+double ContainerBox::get_width(int unit_type){
+    if(width_str != ""){
+        width = LengthPair::get_pair(width_str);
+    }
+
+    if(unit_type == LengthUnit::NOT_SET) return 0;
+    
+    Size2 window_size = get_tree()->get_root()->get_visible_rect().size;
+    if(parent == nullptr){
+        return ContainerUnitConverter::get_width(width, window_size.x, window_size, unit_type);
+    }
+
+    return ContainerUnitConverter::get_width(width, parent->get_width(), window_size, unit_type);
+}
+
+void ContainerBox::set_width(double length, int unit_type){
+    ContainerBox::width.length = length;
+    ContainerBox::width.unit_type = unit_type;
+}
+
+double ContainerBox::editor_get_width(int unit_type)
+{
+    if(height_str != ""){
+        height = LengthPair::get_pair(height_str);
+    }
+    if(unit_type == LengthUnit::NOT_SET) return 0;
+
+    Size2 window_size = Size2(
+        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_width"), 
+        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_height"));
+
+    if(parent == nullptr){
+        return ContainerUnitConverter::get_width(width, window_size.x, window_size, unit_type);
+    }
+
+    return ContainerUnitConverter::get_width(width, parent->get_width(), window_size, unit_type);
+}
+
+void ContainerBox::set_width_str(String length_and_unit){
+    width_str = length_and_unit;
+    width = LengthPair::get_pair(length_and_unit);
+}
+
+String ContainerBox::get_width_str()
+{
+    return width_str;
+}
+
+void ContainerBox::set_height(double length, int unit_type){
+    ContainerBox::height.length = length;
+    ContainerBox::height.unit_type = unit_type;
+}
+
+void ContainerBox::set_height_str(String length_and_unit){
+    height_str = length_and_unit; 
+    height = LengthPair::get_pair(length_and_unit);
+}
+
+String ContainerBox::get_height_str()
+{
+    return height_str;
+}
+
+double ContainerBox::get_height(int unit_type){
+    if(unit_type == LengthUnit::NOT_SET) return 0;
+
+    Size2 window_size = get_tree()->get_root()->get_visible_rect().size;
+
+    if(parent == nullptr){
+        Size2 window_size = get_tree()->get_root()->get_visible_rect().size;
+        return ContainerUnitConverter::get_height(height, window_size.y, window_size, unit_type);
+    }
+
+    return ContainerUnitConverter::get_height(height, parent->get_height(), window_size, unit_type);
+}
+
+double ContainerBox::editor_get_height(int unit_type)
+{    
+    if(unit_type == LengthUnit::NOT_SET) return 0;
+
+    Size2 window_size = Size2(
+        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_width"), 
+        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_height"));
+
+    if(parent == nullptr){
+        return ContainerUnitConverter::get_height(height, window_size.y, window_size, unit_type);
+    }
+
+    return ContainerUnitConverter::get_height(height, parent->get_height(), window_size, unit_type);
+}
+
+void ContainerBox::_bind_methods(){
+    ClassDB::bind_method(D_METHOD("set_width", "length", "unit_type"), &ContainerBox::set_width);
+    ClassDB::bind_method(D_METHOD("get_width", "unit_type"), &ContainerBox::get_width);
+    ClassDB::bind_method(D_METHOD("set_height", "length", "unit_type"), &ContainerBox::set_height);
+    ClassDB::bind_method(D_METHOD("get_height", "unit_type"), &ContainerBox::get_height);
+
+    ClassDB::bind_method(D_METHOD("set_width_str", "length_and_unit"), &ContainerBox::set_width_str);
+    ClassDB::bind_method(D_METHOD("get_width_str"), &ContainerBox::get_width_str);    
+    ClassDB::bind_method(D_METHOD("set_height_str", "length_and_unit"), &ContainerBox::set_height_str);
+    ClassDB::bind_method(D_METHOD("get_height_str"), &ContainerBox::get_height_str);
+
+    ClassDB::bind_method(D_METHOD("set_debug_outputs", "debug_outputs"), &ContainerBox::set_debug_outputs);
+    ClassDB::bind_method(D_METHOD("get_debug_outputs"), &ContainerBox::get_debug_outputs);
+}
+
+bool ContainerBox::_set(const StringName &p_name, const Variant &p_value)
+{
+    String name = p_name;
+	if (name == "width_str") {
+		set_width_str(p_value);
+		return true;
+	}else if(name == "height_str"){
+        set_height_str(p_value);
+        return true;
+    }else if(name == "debug_outputs"){
+        set_debug_outputs(p_value);
+    	return true;
+    }
+	return false;
+}
+
+bool ContainerBox::_get(const StringName &p_name, Variant &r_ret) const
+{
+    String name = p_name;
+	if (name == "width_str") {
+	    r_ret = width_str;
+		return true;
+	}else if(name == "height_str"){
+        r_ret = height_str;
+        return true;
+    }else if(name == "debug_outputs"){
+        r_ret = debug_outputs;
+    	return true;
+    }
+	return false;
+}
+
+void ContainerBox::_get_property_list(List<PropertyInfo> *p_list) const
+{
+    p_list->push_back(PropertyInfo(Variant::STRING, "width_str"));
+    p_list->push_back(PropertyInfo(Variant::STRING, "height_str"));
+    p_list->push_back(PropertyInfo(Variant::BOOL, "debug_outputs"));
+}

--- a/src/core/units/unit.cpp
+++ b/src/core/units/unit.cpp
@@ -1,0 +1,73 @@
+#include "core/units/unit.h"
+#include "commons/string_helper.h"
+
+LengthPair::LengthPair(int unit_type, double length)
+{
+    LengthPair::unit_type = unit_type;
+    LengthPair::length = length;
+}
+
+LengthPair LengthPair::get_pair(String string_pair){
+    string_pair = replace(string_pair, " ", "");
+    String value_string;
+    String unit_string;
+
+    for (size_t i = 0; i < string_pair.length(); i++)
+    {
+        if (string_pair[i] == '0' || string_pair[i] == '1' || string_pair[i] == '2' || string_pair[i] == '3' || 
+            string_pair[i] == '4' || string_pair[i] == '5' || string_pair[i] == '6' || string_pair[i] == '7' || 
+            string_pair[i] == '8' || string_pair[i] == '9' || string_pair[i] == '.') {
+            value_string += string_pair[i];
+        } else {
+            unit_string += string_pair[i];
+        }
+    }
+
+    double value = value_string.to_float();
+    int unit = get_unit(unit_string);
+
+    // Converts into an actual float percentage
+    if(unit == LengthUnit::PERCENTAGE){
+        value = value/100;
+    }
+
+    return LengthPair(unit, value);
+}
+
+String LengthPair::get_pair_str(LengthPair pair){
+    String pair_str;
+    pair_str += String::num(pair.length);
+    switch (pair.unit_type)
+    {
+        case LengthUnit::PIXEL:
+            pair_str += "px";
+            break;
+        case LengthUnit::PERCENTAGE:
+            pair_str += "%";
+            break;
+        case LengthUnit::VIEWPORT_WIDTH:
+            pair_str += "vw";
+            break;
+        case LengthUnit::VIEWPORT_HEIGHT:
+            pair_str += "vh";
+            break;
+        default:
+            return pair_str + pair.unit_type;
+    }
+
+    return pair_str;
+}
+
+int LengthPair::get_unit(String unit_string){
+    if(unit_string == "px"){
+        return LengthUnit::PIXEL;
+    }else if(unit_string == "%"){
+        return LengthUnit::PERCENTAGE;
+    }else if(unit_string == "vh"){
+        return LengthUnit::VIEWPORT_HEIGHT;
+    }else if(unit_string == "vw"){
+        return LengthUnit::VIEWPORT_WIDTH;
+    }else{
+        return LengthUnit::NOT_SET;
+    }
+}

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -2,6 +2,8 @@
 #include <gdextension_interface.h>
 #include <godot_cpp/core/defs.hpp>
 #include <godot_cpp/godot.hpp>
+#include "containers/container_box.h"
+#include "commons/unit_converter.h"
 
 using namespace godot;
 
@@ -9,6 +11,9 @@ void initialize_harmonia(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
+
+	GDREGISTER_CLASS(LengthUnit);
+	GDREGISTER_CLASS(ContainerBox);
 }
 
 void deinitialize_harmonia(ModuleInitializationLevel p_level) {


### PR DESCRIPTION
Adds ContainerBox - Godot Control class
ContainerBox works both in the editor and in runtime.

This brings height and width features, conversion features and other into container box

Adds unit conversion and wrapper for container unit conversion. Supported Units:
- Pixel
- Percentage
- Viewport width
- Viewport height

Tested on Godot 4.3