### PR TITLE
Margins, backgrounds, split, and bugfixes

### DIFF
--- a/include/commons/string_helper.h
+++ b/include/commons/string_helper.h
@@ -2,6 +2,7 @@
 
 #include <godot_cpp/godot.hpp>
 #include <godot_cpp/variant/string.hpp>
+#include <godot_cpp/templates/list.hpp>
 
 using namespace godot;
 
@@ -11,3 +12,4 @@ using namespace godot;
 /// @param to String to replace string instances with
 /// @return String with replaced strings to another string
 String replace(String str, String replace, String to);
+List<String> split(String str, String seperator, bool ignore_empty = true);

--- a/include/commons/string_helper.h
+++ b/include/commons/string_helper.h
@@ -12,4 +12,10 @@ using namespace godot;
 /// @param to String to replace string instances with
 /// @return String with replaced strings to another string
 String replace(String str, String replace, String to);
+
+/// @brief Splits the string into a list by the given seperator.
+/// @param str Original string to be split
+/// @param seperator The seperator that should be used to split the string.
+/// @param ignore_empty Should empty split results be ignored? 
+/// @return A list of all strings split by a seperator.
 List<String> split(String str, String seperator, bool ignore_empty = true);

--- a/include/containers/container_box.h
+++ b/include/containers/container_box.h
@@ -40,11 +40,32 @@ public:
     void ContainerBox::_ready();
     void ContainerBox::_process(double delta);
     void ContainerBox::_gui_input(const Ref<InputEvent> &p_gui_input);
+
+    /// @brief Functions as _draw but doesnt override the _draw instead it's used when draw notification is emmited.  
     void draw_ui();
 
+    /// @brief Helper function for getting width of a provided LengthPair in any Harmonia unit. (Here to remove repetitions)
+    /// @param pair The LengthPair you want the width from.
+    /// @param unit_type Harmonia unit you want the width to be in.
+    /// @return Width in the specified unit you want.
     double get_width_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type);
+
+    /// @brief Helper function for getting height of a provided LengthPair in any Harmonia unit. (Here to remove repetitions)
+    /// @param pair The LengthPair you want the height from.
+    /// @param unit_type Harmonia unit you want the height to be in.
+    /// @return Height in the specified unit you want.
     double get_height_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type);
+
+    /// @brief [EDITOR] Helper function for getting height of a provided LengthPair in any Harmonia unit specifically for editor (Here to remove repetitions)
+    /// @param pair The LengthPair you want the height from.
+    /// @param unit_type Harmonia unit you want the height to be in.
+    /// @return Height in the specified unit you want.
     double editor_get_width_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type);
+
+    /// @brief [EDITOR] Helper function for getting width of a provided LengthPair in any Harmonia unit specifically for editor (Here to remove repetitions)
+    /// @param pair The LengthPair you want the width from.
+    /// @param unit_type Harmonia unit you want the width to be in.
+    /// @return Width in the specified unit you want.
     double editor_get_height_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type);
 
     /// @brief Updates the container presentation/view in runtime
@@ -59,7 +80,9 @@ public:
     
     /// @brief Alert manager of this containers. Bind to this manager if you want to react to this containers alerts
     AlertManager* alert_manager = memnew(AlertManager);
+    /// @brief A simple getter for alert manager of this container
     AlertManager* get_alert_manager();
+    /// @brief A simple setter for alert manager of this container
     void set_alert_manager(AlertManager* manager);
 
     /// @brief ContainerBox parent of this container, only ContainerBox classes are set.
@@ -69,41 +92,86 @@ public:
     /// @return ContainerBox parent or nullptr
     ContainerBox* get_parent_container();
 
-    // Margins go: up right down left
+    /// NOTE: Margins go: [0: up] [1: right] [2: down] [3: left]
 
+    /// @brief Margins in string which later gets processed to retrieve up/down/left/right margins. 
     String margin_str;
+    /// @brief Setter for string margin, processes the new margin in order to retrieve actual margins.
     void set_margin_str(String new_margin);
+    /// @brief Simple getter for string margin. 
     String get_margin_str();
 
-    void set_margin_all(double all_sides, Harmonia::Unit unit_type = Harmonia::PIXEL);
-    void set_margin_y_vertical(double vertical_y, Harmonia::Unit vertical_unit = Harmonia::PIXEL);
-    void set_margin_x_horizontal(double horizontal_x, Harmonia::Unit horizontal_unit = Harmonia::PIXEL);
+    /// @brief A helper function to set all margins with the same value and unit.
+    /// @param all_sides value of each side.
+    /// @param unit_type unit type of each side.
+    void set_margin_all(double all_sides, Harmonia::Unit unit_type = Harmonia::PIXEL, bool dispatch_alert = true);
+    /// @brief A helper function to set margins on the y/vertical axis (specifically down/up)
+    /// @param vertical_y value of each y/vertical sides (down/up)
+    /// @param vertical_unit unit type of each y/vertical sides (down/up)
+    void set_margin_y_vertical(double vertical_y, Harmonia::Unit vertical_unit = Harmonia::PIXEL, bool dispatch_alert = true);
+    
+    /// @brief A helper function to set margins on the x/horizontal axis (specifically left/right)
+    /// @param horizontal_x value of each x/horizontal sides (left/right)
+    /// @param horizontal_unit unit type of each x/horizontal sides (left/right)
+    void set_margin_x_horizontal(double horizontal_x, Harmonia::Unit horizontal_unit = Harmonia::PIXEL, bool dispatch_alert = true);
 
-    TypedArray<double> get_margins(Harmonia::Unit unit_type);
-    TypedArray<double> editor_get_margins(Harmonia::Unit unit_type);
+    /// @brief A helper function to get all margins as a typed array. 
+    /// 
+    /// indexes values are: 0-up, 1-right, 2-down, 3-left 
+    /// @param unit_type what unit type should the margins be in.
+    TypedArray<double> get_margins(Harmonia::Unit unit_type = Harmonia::PIXEL);
 
+    /// @brief [EDITOR] A helper function to get all margins as a typed array for the editor. 
+    ///
+    /// indexes values are: 0-up, 1-right, 2-down, 3-left 
+    /// @param unit_type what unit type should the margins be in.
+    TypedArray<double> editor_get_margins(Harmonia::Unit unit_type = Harmonia::PIXEL);
+
+    /// @brief Upper(Up) margin of this container
     LengthPair margin_up;
-    void set_margin_up(double up, Harmonia::Unit up_unit);
+    /// @brief Simple setter for the upper(Up) margin, dispatches an alert.
+    /// @param dispatch_alert Whether an alert for margin change should be dispatched
+    void set_margin_up(double up, Harmonia::Unit up_unit, bool dispatch_alert = true);
+    /// @brief Simple getter for the upper(Up) margin in any harmonia unit
     double get_margin_up(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+    /// @brief [EDITOR] Simple getter for the upper(Up) margin in any harmonia unit
     double editor_get_margin_up(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
-
+    
+    /// @brief Lower(Down) margin of this container
     LengthPair margin_down;
-    void set_margin_down(double down, Harmonia::Unit down_unit);
+    /// @brief Simple setter for the lower(Down) margin, dispatches an alert.
+    /// @param dispatch_alert Whether an alert for margin change should be dispatched
+    void set_margin_down(double down, Harmonia::Unit down_unit, bool dispatch_alert = true);
+    /// @brief Simple getter for the lower(Down) margin in any harmonia unit
     double get_margin_down(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+    /// @brief [EDITOR] Simple getter for the lower(Down) margin in any harmonia unit
     double editor_get_margin_down(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
 
+    /// @brief Left margin of this container
     LengthPair margin_left;
-    void set_margin_left(double left, Harmonia::Unit left_unit);
+    /// @brief Simple setter for the left margin, dispatches an alert.
+    /// @param dispatch_alert Whether an alert for margin change should be dispatched
+    void set_margin_left(double left, Harmonia::Unit left_unit, bool dispatch_alert = true);
+    /// @brief Simple getter for the left margin in any harmonia unit
     double get_margin_left(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+    /// @brief [EDITOR] Simple getter for the left margin in any harmonia unit
     double editor_get_margin_left(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
-
+   
+    /// @brief Right margin of this container
     LengthPair margin_right;
-    void set_margin_right(double right, Harmonia::Unit right_unit);
+    /// @brief Simple setter for the right margin, dispatches an alert.
+    /// @param dispatch_alert Whether an alert for margin change should be dispatched
+    void set_margin_right(double right, Harmonia::Unit right_unit, bool dispatch_alert = true);
+    /// @brief Simple getter for the right margin in any harmonia unit
     double get_margin_right(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+    /// @brief [EDITOR] Simple getter for the right margin in any harmonia unit
     double editor_get_margin_right(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
 
+    /// @brief Background color of this container, by default transparent.
     Color background_color = Color(0, 0, 0, 0);
+    /// @brief Simple getter for the background color of this container
     Color get_background_color();
+    /// @brief Simple setter for the background color of this container. Additionally calls for redraw so setting background color has a close to immediate effect.
     void set_background_color(Color color);
 
     /// @brief The type of positioning of this containers children. Default STATIC.
@@ -114,8 +182,8 @@ public:
     /// @brief Returns the positioning type for this containers children
     Position get_position_type();
     
-    /// BELOW Str pos are positions set in the editor or in the code using getter/setter
-    /// They string posistions get processed to create a pos_x length pair. Ex of str pos: 10%, 10px
+    /// NOTE: BELOW Str pos are positions set in the editor or in the code using getter/setter
+    /// The string positions get processed to create a pos_x length pair. Ex of str pos: 10%, 10px
 
     /// @brief X Position of this container.
     LengthPair pos_x;

--- a/include/containers/container_box.h
+++ b/include/containers/container_box.h
@@ -18,9 +18,7 @@ class ContainerBox : public Control
 public:
     ContainerBox() = default;
     ~ContainerBox() = default;
-    
-    // Constants:
-    
+        
     /// @brief Alert of layout change, that being position, width, height or other layout change
     const String ALERT_LAYOUT_CHANGE = "layout-change";
 
@@ -33,15 +31,21 @@ public:
 
     /// @brief Update time from the last update
     /// @note This will get removed in the future.
-    double update_time = 0;
+    double update_time {0};
 
     /// @brief The interval of updates 
     /// @note This will get removed in the future.
-    double update_interval = 1.0;
+    double update_interval {1.0};
 
     void ContainerBox::_ready();
     void ContainerBox::_process(double delta);
     void ContainerBox::_gui_input(const Ref<InputEvent> &p_gui_input);
+    void draw_ui();
+
+    double get_width_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type);
+    double get_height_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type);
+    double editor_get_width_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type);
+    double editor_get_height_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type);
 
     /// @brief Updates the container presentation/view in runtime
     void update_presentation();
@@ -64,9 +68,46 @@ public:
     /// @brief gets containerBox parent of this container if one exists.
     /// @return ContainerBox parent or nullptr
     ContainerBox* get_parent_container();
-    
+
+    // Margins go: up right down left
+
+    String margin_str;
+    void set_margin_str(String new_margin);
+    String get_margin_str();
+
+    void set_margin_all(double all_sides, Harmonia::Unit unit_type = Harmonia::PIXEL);
+    void set_margin_y_vertical(double vertical_y, Harmonia::Unit vertical_unit = Harmonia::PIXEL);
+    void set_margin_x_horizontal(double horizontal_x, Harmonia::Unit horizontal_unit = Harmonia::PIXEL);
+
+    TypedArray<double> get_margins(Harmonia::Unit unit_type);
+    TypedArray<double> editor_get_margins(Harmonia::Unit unit_type);
+
+    LengthPair margin_up;
+    void set_margin_up(double up, Harmonia::Unit up_unit);
+    double get_margin_up(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+    double editor_get_margin_up(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+
+    LengthPair margin_down;
+    void set_margin_down(double down, Harmonia::Unit down_unit);
+    double get_margin_down(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+    double editor_get_margin_down(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+
+    LengthPair margin_left;
+    void set_margin_left(double left, Harmonia::Unit left_unit);
+    double get_margin_left(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+    double editor_get_margin_left(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+
+    LengthPair margin_right;
+    void set_margin_right(double right, Harmonia::Unit right_unit);
+    double get_margin_right(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+    double editor_get_margin_right(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+
+    Color background_color = Color(0, 0, 0, 0);
+    Color get_background_color();
+    void set_background_color(Color color);
+
     /// @brief The type of positioning of this containers children. Default STATIC.
-    Position position_type = Position::STATIC;
+    Position position_type {Position::STATIC};
 
     /// @brief Sets a positioning type for this containers children.
     void set_position_type(Position new_type);

--- a/include/core/harmonia.h
+++ b/include/core/harmonia.h
@@ -40,10 +40,10 @@ struct LengthPair{
     /// @brief The unit of the value
     ///
     /// For simpliticy of calculations: % are actual precentages in length ex. 10% is 0.1
-    Harmonia::Unit unit_type;
+    Harmonia::Unit unit_type {Harmonia::Unit::NOT_SET};
     
     /// @brief The value - length of the pair
-    double length;
+    double length {0};
 
     /// @brief Constructs a Length pair with existing unit and length
     /// @param unit_type The unit of the value/length

--- a/include/core/systems/alert/layout/alert_layout_change.h
+++ b/include/core/systems/alert/layout/alert_layout_change.h
@@ -1,26 +1,29 @@
 #include <godot_cpp/core/class_db.hpp>
 #include "core/systems/alert/alert.h"
 
-/// @brief Work In Progress. This class will allow you to bind to a layout change alert in a alert system.
+/// @brief Class which allows for binding for size, position, or margin layout changes
 class AlertLayoutChange : public Alert
 {
+    GDCLASS(AlertLayoutChange, Alert);
 public:
     enum LayoutChanged {
+        UNSPECIFIED,
         WIDTH,
         HEIGHT,
         POSITION,
         MARGIN,
         PADDING,
-        // ... Other will be added
     };
 
     AlertLayoutChange() = default;
     AlertLayoutChange(String name, LayoutChanged changed);
     
-    LayoutChanged layout_changed;
+    /// @brief The specific layout that was changed.
+    LayoutChanged layout_changed {LayoutChanged::UNSPECIFIED};
+    /// @brief Gets this alerts name 
     String get_alert_name() const;
 protected:
-    void _bind_methods();
+    static void _bind_methods();
 };
 
 inline String AlertLayoutChange::get_alert_name() const

--- a/include/core/systems/alert/layout/alert_layout_change.h
+++ b/include/core/systems/alert/layout/alert_layout_change.h
@@ -8,7 +8,9 @@ public:
     enum LayoutChanged {
         WIDTH,
         HEIGHT,
-        POSITION
+        POSITION,
+        MARGIN,
+        PADDING,
         // ... Other will be added
     };
 

--- a/src/commons/string_helper.cpp
+++ b/src/commons/string_helper.cpp
@@ -7,11 +7,6 @@ String replace(String str, String replace, String to){
     unsigned int index = 0;
     for (unsigned int i = 0; i < str_length; i++)
     {   
-        if(index > 0){
-            index -= 1;
-            continue;
-        }
-
         for (size_t o = 0; o < replace_length; o++)
         {
             if(str_length - i >= replace_length){
@@ -27,13 +22,56 @@ String replace(String str, String replace, String to){
             }
         }
         
-        if(index > 0){
-            index -= 1;
+        if(index == replace_length){
             result += to;
-            continue;
-        }else{
+            i += index-1; // -1 because it doesnt count this iteration which is also a part of replaced string.
+            index = 0;
+        }
+        else {
             result += str[i];
         }
     }
+    return result;
+}
+
+List<String> split(String str, String seperator, bool ignore_empty){
+
+    List<String> result;
+    unsigned int str_length = str.length();
+    unsigned int seperator_length = seperator.length();
+    unsigned int seperator_match = 0;
+
+    String current_split;
+    for (unsigned int i = 0; i < str_length; i++)
+    {
+        if(str[i+seperator_match] == seperator[seperator_match]){
+            seperator_match++;
+        }else {
+            if(seperator_match > 0){
+                for (size_t o = 0; o < seperator_match; o++)
+                {
+                    current_split += seperator[o];
+                }
+            }
+            current_split += str[i];
+        }
+
+        if(seperator_match == seperator_length){
+            if(current_split != ""){
+                result.push_back(current_split);
+            }else if(!ignore_empty && current_split == ""){
+                result.push_back(current_split);
+            }
+            current_split = "";
+            seperator_match = 0;
+        }
+    }
+
+    if(current_split != ""){
+        result.push_back(current_split);
+    }else if(!ignore_empty && current_split == ""){
+        result.push_back(current_split);
+    }
+
     return result;
 }

--- a/src/containers/container_box.cpp
+++ b/src/containers/container_box.cpp
@@ -118,7 +118,7 @@ void ContainerBox::update_presentation(){
 
 void ContainerBox::update_children_position(TypedArray<Node> children){
     Vector2 position = Vector2(0, 0);
-    // Add margin, padding - Future update.
+    // Add padding - Future update.
     
     for (size_t i = 0; i < children.size(); i++)
     {
@@ -159,7 +159,7 @@ void ContainerBox::editor_update_children_position(TypedArray<Node> children)
 {
     Vector2 position = Vector2(0, 0);
 
-    // Add margin, padding - Future update.
+    // Add padding - Future update.
     for (size_t i = 0; i < children.size(); i++)
     {
         auto current_child = children[i];
@@ -208,7 +208,7 @@ void ContainerBox::set_margin_str(String new_margin){
     if(margin_size == 2){
         LengthPair margin_y = LengthPair::get_pair(margins[0]);
         LengthPair margin_x = LengthPair::get_pair(margins[1]);
-        set_margin_y_vertical(margin_y.length, margin_y.unit_type);
+        set_margin_y_vertical(margin_y.length, margin_y.unit_type, false); // false to avoid duplicate alert.
         set_margin_x_horizontal(margin_x.length, margin_x.unit_type);
         if(debug_outputs) UtilityFunctions::print("Extracted 2 margins:", margin_y.length, margin_x.length);
     }
@@ -235,7 +235,7 @@ String ContainerBox::get_margin_str(){
     return margin_str;
 }
 
-void ContainerBox::set_margin_all(double all_sides, Harmonia::Unit unit_type){
+void ContainerBox::set_margin_all(double all_sides, Harmonia::Unit unit_type, bool dispatch_alert){
     margin_up.length = all_sides;
     margin_up.unit_type = unit_type;
     margin_right.length = all_sides;
@@ -244,48 +244,48 @@ void ContainerBox::set_margin_all(double all_sides, Harmonia::Unit unit_type){
     margin_down.unit_type = unit_type;
     margin_left.length = all_sides;
     margin_left.unit_type = unit_type;
-    alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
+    if (dispatch_alert) alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
 }
 
-void ContainerBox::set_margin_y_vertical(double vertical_y, Harmonia::Unit vertical_unit){
+void ContainerBox::set_margin_y_vertical(double vertical_y, Harmonia::Unit vertical_unit, bool dispatch_alert){
     margin_up.length = vertical_y;
     margin_up.unit_type = vertical_unit;
     margin_down.length = vertical_y;
     margin_down.unit_type = vertical_unit;
-    alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
+    if (dispatch_alert) alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
 }
 
-void ContainerBox::set_margin_x_horizontal(double horizontal_x, Harmonia::Unit horizontal_unit){
+void ContainerBox::set_margin_x_horizontal(double horizontal_x, Harmonia::Unit horizontal_unit, bool dispatch_alert){
     margin_right.length = horizontal_x;
     margin_right.unit_type = horizontal_unit;
     margin_left.length = horizontal_x;
     margin_left.unit_type = horizontal_unit;
-    alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
+    if (dispatch_alert) alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
 }
 
 TypedArray<double> ContainerBox::get_margins(Harmonia::Unit unit_type){
     // up right down left
     TypedArray<double> margins;
-    margins[0] = get_margin_up();
-    margins[1] = get_margin_right();
-    margins[2] = get_margin_down();
-    margins[3] = get_margin_left();
+    margins[0] = get_margin_up(unit_type);
+    margins[1] = get_margin_right(unit_type);
+    margins[2] = get_margin_down(unit_type);
+    margins[3] = get_margin_left(unit_type);
     return margins;
 }
 
 TypedArray<double> ContainerBox::editor_get_margins(Harmonia::Unit unit_type){
     TypedArray<double> margins;
-    margins[0] = editor_get_margin_up();
-    margins[1] = editor_get_margin_right();
-    margins[2] = editor_get_margin_down();
-    margins[3] = editor_get_margin_left();
+    margins[0] = editor_get_margin_up(unit_type);
+    margins[1] = editor_get_margin_right(unit_type);
+    margins[2] = editor_get_margin_down(unit_type);
+    margins[3] = editor_get_margin_left(unit_type);
     return margins;
 }
 
-void ContainerBox::set_margin_up(double up, Harmonia::Unit up_unit){
+void ContainerBox::set_margin_up(double up, Harmonia::Unit up_unit, bool dispatch_alert){
     margin_up.length = up;
     margin_up.unit_type = up_unit;
-    alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
+    if (dispatch_alert) alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
 }
 
 double ContainerBox::get_margin_up(Harmonia::Unit unit_type){
@@ -296,10 +296,10 @@ double ContainerBox::editor_get_margin_up(Harmonia::Unit unit_type){
     return editor_get_height_length_pair_unit(margin_up, unit_type);
 }
 
-void ContainerBox::set_margin_down(double down, Harmonia::Unit down_unit){
+void ContainerBox::set_margin_down(double down, Harmonia::Unit down_unit, bool dispatch_alert){
     margin_down.length = down;
     margin_down.unit_type = down_unit;
-    alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
+    if (dispatch_alert) alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
 }
 
 double ContainerBox::get_margin_down(Harmonia::Unit unit_type){
@@ -310,10 +310,10 @@ double ContainerBox::editor_get_margin_down(Harmonia::Unit unit_type){
     return editor_get_height_length_pair_unit(margin_down, unit_type);
 }
 
-void ContainerBox::set_margin_left(double left, Harmonia::Unit left_unit){
+void ContainerBox::set_margin_left(double left, Harmonia::Unit left_unit, bool dispatch_alert){
     margin_left.length = left;
     margin_left.unit_type = left_unit;
-    alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
+    if (dispatch_alert) alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
 }
 double ContainerBox::get_margin_left(Harmonia::Unit unit_type){
     return get_width_length_pair_unit(margin_left, unit_type);
@@ -323,10 +323,10 @@ double ContainerBox::editor_get_margin_left(Harmonia::Unit unit_type){
     return editor_get_width_length_pair_unit(margin_left, unit_type);
 }
 
-void ContainerBox::set_margin_right(double right, Harmonia::Unit right_unit){
+void ContainerBox::set_margin_right(double right, Harmonia::Unit right_unit, bool dispatch_alert){
     margin_right.length = right;
     margin_right.unit_type = right_unit;
-    alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));    
+    if (dispatch_alert) alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));    
 }
 
 double ContainerBox::get_margin_right(Harmonia::Unit unit_type){

--- a/src/containers/container_box.cpp
+++ b/src/containers/container_box.cpp
@@ -511,9 +511,22 @@ void ContainerBox::_bind_methods(){
     ClassDB::bind_method(D_METHOD("set_pos_y", "new_y", "unit_type"), &ContainerBox::set_pos_y);
     ClassDB::bind_method(D_METHOD("get_pos_y", "unit_type"), &ContainerBox::get_pos_y);
 
+    ClassDB::bind_method(D_METHOD("set_margin_all", "all_sides", "unit_type", "dispatch_alert"), &ContainerBox::set_margin_all, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("set_margin_y_vertical", "vertical_y", "vertical_unit", "dispatch_alert"), &ContainerBox::set_margin_y_vertical, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("set_margin_x_horizontal", "horizontal_x", "horizontal_unit", "dispatch_alert"), &ContainerBox::set_margin_x_horizontal, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("get_margins", "unit_type"), &ContainerBox::get_margins, DEFVAL(Harmonia::PIXEL));
+
     ClassDB::bind_method(D_METHOD("set_margin_str", "new_margin"), &ContainerBox::set_margin_str);
     ClassDB::bind_method(D_METHOD("get_margin_str"), &ContainerBox::get_margin_str);
-
+    ClassDB::bind_method(D_METHOD("set_margin_up", "up_margin", "up_unit", "dispatch_alert"), &ContainerBox::set_margin_up, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("get_margin_up", "unit_type"), &ContainerBox::get_margin_up, DEFVAL(Harmonia::PIXEL));
+    ClassDB::bind_method(D_METHOD("set_margin_right", "right_margin", "right_unit", "dispatch_alert"), &ContainerBox::set_margin_right, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("get_margin_right", "unit_type"), &ContainerBox::get_margin_right, DEFVAL(Harmonia::PIXEL));
+    ClassDB::bind_method(D_METHOD("set_margin_down", "down_margin", "down_unit", "dispatch_alert"), &ContainerBox::set_margin_down, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("get_margin_down", "unit_type"), &ContainerBox::get_margin_down, DEFVAL(Harmonia::PIXEL));
+    ClassDB::bind_method(D_METHOD("set_margin_left", "left_margin", "left_unit", "dispatch_alert"), &ContainerBox::set_margin_left, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("get_margin_left", "unit_type"), &ContainerBox::get_margin_left, DEFVAL(Harmonia::PIXEL));
+    
     ClassDB::bind_method(D_METHOD("set_background_color", "color"), &ContainerBox::set_background_color);
     ClassDB::bind_method(D_METHOD("get_background_color"), &ContainerBox::get_background_color);
 

--- a/src/core/systems/alert/layout/alert_layout_change.cpp
+++ b/src/core/systems/alert/layout/alert_layout_change.cpp
@@ -5,3 +5,12 @@ AlertLayoutChange::AlertLayoutChange(String name, LayoutChanged changed)
     alert_name = name;
     layout_changed = changed;
 }
+
+void AlertLayoutChange::_bind_methods()
+{
+    BIND_ENUM_CONSTANT(AlertLayoutChange::WIDTH);
+    BIND_ENUM_CONSTANT(AlertLayoutChange::HEIGHT);
+    BIND_ENUM_CONSTANT(AlertLayoutChange::POSITION);
+    BIND_ENUM_CONSTANT(AlertLayoutChange::MARGIN);
+    BIND_ENUM_CONSTANT(AlertLayoutChange::PADDING);
+}

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -6,6 +6,7 @@
 #include "containers/container_box.h"
 #include "commons/unit_converter.h"
 #include "core/systems/alert/alert.h"
+#include "core/systems/alert/layout/alert_layout_change.h"
 #include "core/systems/alert/alert_manager.h"
 
 using namespace godot;
@@ -17,6 +18,7 @@ void initialize_harmonia(ModuleInitializationLevel p_level) {
 
 	GDREGISTER_CLASS(Harmonia);
 	GDREGISTER_VIRTUAL_CLASS(Alert);
+	GDREGISTER_CLASS(AlertLayoutChange);
 	GDREGISTER_CLASS(AlertManager);
 	GDREGISTER_CLASS(ContainerBox);
 }


### PR DESCRIPTION
Adds margins up right down left.
 - Note: for this specific container the right margin is not used, this is because the base container flow makes it unnecessary, however the right margin will be used in different container types.

Added LayoutChanged values into enum for Margin and padding (will be added later).

Adds background color possibility using draw notifications and canvas item draw functions. Adds split function into string helper file.

Fixes replace function in string helper file, where previously the function would run in a loop to decrease the index, now the index value is simply added into iterator

Fixes length pair and other variables without default value, now replaced with default initialization value of 0. Before fix this caused the unset values like positions/sizes and other to have unwanted garbage values where really 0 was wanted.