### PR TITLE
Margins, backgrounds, split, and bugfixes (#4)

### DIFF
--- a/include/commons/string_helper.h
+++ b/include/commons/string_helper.h
@@ -2,6 +2,7 @@
 
 #include <godot_cpp/godot.hpp>
 #include <godot_cpp/variant/string.hpp>
+#include <godot_cpp/templates/list.hpp>
 
 using namespace godot;
 
@@ -11,3 +12,10 @@ using namespace godot;
 /// @param to String to replace string instances with
 /// @return String with replaced strings to another string
 String replace(String str, String replace, String to);
+
+/// @brief Splits the string into a list by the given seperator.
+/// @param str Original string to be split
+/// @param seperator The seperator that should be used to split the string.
+/// @param ignore_empty Should empty split results be ignored? 
+/// @return A list of all strings split by a seperator.
+List<String> split(String str, String seperator, bool ignore_empty = true);

--- a/include/containers/container_box.h
+++ b/include/containers/container_box.h
@@ -18,9 +18,7 @@ class ContainerBox : public Control
 public:
     ContainerBox() = default;
     ~ContainerBox() = default;
-    
-    // Constants:
-    
+        
     /// @brief Alert of layout change, that being position, width, height or other layout change
     const String ALERT_LAYOUT_CHANGE = "layout-change";
 
@@ -33,15 +31,42 @@ public:
 
     /// @brief Update time from the last update
     /// @note This will get removed in the future.
-    double update_time = 0;
+    double update_time {0};
 
     /// @brief The interval of updates 
     /// @note This will get removed in the future.
-    double update_interval = 1.0;
+    double update_interval {1.0};
 
     void ContainerBox::_ready();
     void ContainerBox::_process(double delta);
     void ContainerBox::_gui_input(const Ref<InputEvent> &p_gui_input);
+
+    /// @brief Functions as _draw but doesnt override the _draw instead it's used when draw notification is emmited.  
+    void draw_ui();
+
+    /// @brief Helper function for getting width of a provided LengthPair in any Harmonia unit. (Here to remove repetitions)
+    /// @param pair The LengthPair you want the width from.
+    /// @param unit_type Harmonia unit you want the width to be in.
+    /// @return Width in the specified unit you want.
+    double get_width_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type);
+
+    /// @brief Helper function for getting height of a provided LengthPair in any Harmonia unit. (Here to remove repetitions)
+    /// @param pair The LengthPair you want the height from.
+    /// @param unit_type Harmonia unit you want the height to be in.
+    /// @return Height in the specified unit you want.
+    double get_height_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type);
+
+    /// @brief [EDITOR] Helper function for getting height of a provided LengthPair in any Harmonia unit specifically for editor (Here to remove repetitions)
+    /// @param pair The LengthPair you want the height from.
+    /// @param unit_type Harmonia unit you want the height to be in.
+    /// @return Height in the specified unit you want.
+    double editor_get_width_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type);
+
+    /// @brief [EDITOR] Helper function for getting width of a provided LengthPair in any Harmonia unit specifically for editor (Here to remove repetitions)
+    /// @param pair The LengthPair you want the width from.
+    /// @param unit_type Harmonia unit you want the width to be in.
+    /// @return Width in the specified unit you want.
+    double editor_get_height_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type);
 
     /// @brief Updates the container presentation/view in runtime
     void update_presentation();
@@ -55,7 +80,9 @@ public:
     
     /// @brief Alert manager of this containers. Bind to this manager if you want to react to this containers alerts
     AlertManager* alert_manager = memnew(AlertManager);
+    /// @brief A simple getter for alert manager of this container
     AlertManager* get_alert_manager();
+    /// @brief A simple setter for alert manager of this container
     void set_alert_manager(AlertManager* manager);
 
     /// @brief ContainerBox parent of this container, only ContainerBox classes are set.
@@ -64,17 +91,99 @@ public:
     /// @brief gets containerBox parent of this container if one exists.
     /// @return ContainerBox parent or nullptr
     ContainerBox* get_parent_container();
+
+    /// NOTE: Margins go: [0: up] [1: right] [2: down] [3: left]
+
+    /// @brief Margins in string which later gets processed to retrieve up/down/left/right margins. 
+    String margin_str;
+    /// @brief Setter for string margin, processes the new margin in order to retrieve actual margins.
+    void set_margin_str(String new_margin);
+    /// @brief Simple getter for string margin. 
+    String get_margin_str();
+
+    /// @brief A helper function to set all margins with the same value and unit.
+    /// @param all_sides value of each side.
+    /// @param unit_type unit type of each side.
+    void set_margin_all(double all_sides, Harmonia::Unit unit_type = Harmonia::PIXEL, bool dispatch_alert = true);
+    /// @brief A helper function to set margins on the y/vertical axis (specifically down/up)
+    /// @param vertical_y value of each y/vertical sides (down/up)
+    /// @param vertical_unit unit type of each y/vertical sides (down/up)
+    void set_margin_y_vertical(double vertical_y, Harmonia::Unit vertical_unit = Harmonia::PIXEL, bool dispatch_alert = true);
     
+    /// @brief A helper function to set margins on the x/horizontal axis (specifically left/right)
+    /// @param horizontal_x value of each x/horizontal sides (left/right)
+    /// @param horizontal_unit unit type of each x/horizontal sides (left/right)
+    void set_margin_x_horizontal(double horizontal_x, Harmonia::Unit horizontal_unit = Harmonia::PIXEL, bool dispatch_alert = true);
+
+    /// @brief A helper function to get all margins as a typed array. 
+    /// 
+    /// indexes values are: 0-up, 1-right, 2-down, 3-left 
+    /// @param unit_type what unit type should the margins be in.
+    TypedArray<double> get_margins(Harmonia::Unit unit_type = Harmonia::PIXEL);
+
+    /// @brief [EDITOR] A helper function to get all margins as a typed array for the editor. 
+    ///
+    /// indexes values are: 0-up, 1-right, 2-down, 3-left 
+    /// @param unit_type what unit type should the margins be in.
+    TypedArray<double> editor_get_margins(Harmonia::Unit unit_type = Harmonia::PIXEL);
+
+    /// @brief Upper(Up) margin of this container
+    LengthPair margin_up;
+    /// @brief Simple setter for the upper(Up) margin, dispatches an alert.
+    /// @param dispatch_alert Whether an alert for margin change should be dispatched
+    void set_margin_up(double up, Harmonia::Unit up_unit, bool dispatch_alert = true);
+    /// @brief Simple getter for the upper(Up) margin in any harmonia unit
+    double get_margin_up(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+    /// @brief [EDITOR] Simple getter for the upper(Up) margin in any harmonia unit
+    double editor_get_margin_up(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+    
+    /// @brief Lower(Down) margin of this container
+    LengthPair margin_down;
+    /// @brief Simple setter for the lower(Down) margin, dispatches an alert.
+    /// @param dispatch_alert Whether an alert for margin change should be dispatched
+    void set_margin_down(double down, Harmonia::Unit down_unit, bool dispatch_alert = true);
+    /// @brief Simple getter for the lower(Down) margin in any harmonia unit
+    double get_margin_down(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+    /// @brief [EDITOR] Simple getter for the lower(Down) margin in any harmonia unit
+    double editor_get_margin_down(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+
+    /// @brief Left margin of this container
+    LengthPair margin_left;
+    /// @brief Simple setter for the left margin, dispatches an alert.
+    /// @param dispatch_alert Whether an alert for margin change should be dispatched
+    void set_margin_left(double left, Harmonia::Unit left_unit, bool dispatch_alert = true);
+    /// @brief Simple getter for the left margin in any harmonia unit
+    double get_margin_left(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+    /// @brief [EDITOR] Simple getter for the left margin in any harmonia unit
+    double editor_get_margin_left(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+   
+    /// @brief Right margin of this container
+    LengthPair margin_right;
+    /// @brief Simple setter for the right margin, dispatches an alert.
+    /// @param dispatch_alert Whether an alert for margin change should be dispatched
+    void set_margin_right(double right, Harmonia::Unit right_unit, bool dispatch_alert = true);
+    /// @brief Simple getter for the right margin in any harmonia unit
+    double get_margin_right(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+    /// @brief [EDITOR] Simple getter for the right margin in any harmonia unit
+    double editor_get_margin_right(Harmonia::Unit unit_type = Harmonia::Unit::PIXEL);
+
+    /// @brief Background color of this container, by default transparent.
+    Color background_color = Color(0, 0, 0, 0);
+    /// @brief Simple getter for the background color of this container
+    Color get_background_color();
+    /// @brief Simple setter for the background color of this container. Additionally calls for redraw so setting background color has a close to immediate effect.
+    void set_background_color(Color color);
+
     /// @brief The type of positioning of this containers children. Default STATIC.
-    Position position_type = Position::STATIC;
+    Position position_type {Position::STATIC};
 
     /// @brief Sets a positioning type for this containers children.
     void set_position_type(Position new_type);
     /// @brief Returns the positioning type for this containers children
     Position get_position_type();
     
-    /// BELOW Str pos are positions set in the editor or in the code using getter/setter
-    /// They string posistions get processed to create a pos_x length pair. Ex of str pos: 10%, 10px
+    /// NOTE: BELOW Str pos are positions set in the editor or in the code using getter/setter
+    /// The string positions get processed to create a pos_x length pair. Ex of str pos: 10%, 10px
 
     /// @brief X Position of this container.
     LengthPair pos_x;

--- a/include/core/harmonia.h
+++ b/include/core/harmonia.h
@@ -40,10 +40,10 @@ struct LengthPair{
     /// @brief The unit of the value
     ///
     /// For simpliticy of calculations: % are actual precentages in length ex. 10% is 0.1
-    Harmonia::Unit unit_type;
+    Harmonia::Unit unit_type {Harmonia::Unit::NOT_SET};
     
     /// @brief The value - length of the pair
-    double length;
+    double length {0};
 
     /// @brief Constructs a Length pair with existing unit and length
     /// @param unit_type The unit of the value/length

--- a/include/core/systems/alert/layout/alert_layout_change.h
+++ b/include/core/systems/alert/layout/alert_layout_change.h
@@ -1,24 +1,29 @@
 #include <godot_cpp/core/class_db.hpp>
 #include "core/systems/alert/alert.h"
 
-/// @brief Work In Progress. This class will allow you to bind to a layout change alert in a alert system.
+/// @brief Class which allows for binding for size, position, or margin layout changes
 class AlertLayoutChange : public Alert
 {
+    GDCLASS(AlertLayoutChange, Alert);
 public:
     enum LayoutChanged {
+        UNSPECIFIED,
         WIDTH,
         HEIGHT,
-        POSITION
-        // ... Other will be added
+        POSITION,
+        MARGIN,
+        PADDING,
     };
 
     AlertLayoutChange() = default;
     AlertLayoutChange(String name, LayoutChanged changed);
     
-    LayoutChanged layout_changed;
+    /// @brief The specific layout that was changed.
+    LayoutChanged layout_changed {LayoutChanged::UNSPECIFIED};
+    /// @brief Gets this alerts name 
     String get_alert_name() const;
 protected:
-    void _bind_methods();
+    static void _bind_methods();
 };
 
 inline String AlertLayoutChange::get_alert_name() const

--- a/src/commons/string_helper.cpp
+++ b/src/commons/string_helper.cpp
@@ -7,11 +7,6 @@ String replace(String str, String replace, String to){
     unsigned int index = 0;
     for (unsigned int i = 0; i < str_length; i++)
     {   
-        if(index > 0){
-            index -= 1;
-            continue;
-        }
-
         for (size_t o = 0; o < replace_length; o++)
         {
             if(str_length - i >= replace_length){
@@ -27,13 +22,56 @@ String replace(String str, String replace, String to){
             }
         }
         
-        if(index > 0){
-            index -= 1;
+        if(index == replace_length){
             result += to;
-            continue;
-        }else{
+            i += index-1; // -1 because it doesnt count this iteration which is also a part of replaced string.
+            index = 0;
+        }
+        else {
             result += str[i];
         }
     }
+    return result;
+}
+
+List<String> split(String str, String seperator, bool ignore_empty){
+
+    List<String> result;
+    unsigned int str_length = str.length();
+    unsigned int seperator_length = seperator.length();
+    unsigned int seperator_match = 0;
+
+    String current_split;
+    for (unsigned int i = 0; i < str_length; i++)
+    {
+        if(str[i+seperator_match] == seperator[seperator_match]){
+            seperator_match++;
+        }else {
+            if(seperator_match > 0){
+                for (size_t o = 0; o < seperator_match; o++)
+                {
+                    current_split += seperator[o];
+                }
+            }
+            current_split += str[i];
+        }
+
+        if(seperator_match == seperator_length){
+            if(current_split != ""){
+                result.push_back(current_split);
+            }else if(!ignore_empty && current_split == ""){
+                result.push_back(current_split);
+            }
+            current_split = "";
+            seperator_match = 0;
+        }
+    }
+
+    if(current_split != ""){
+        result.push_back(current_split);
+    }else if(!ignore_empty && current_split == ""){
+        result.push_back(current_split);
+    }
+
     return result;
 }

--- a/src/containers/container_box.cpp
+++ b/src/containers/container_box.cpp
@@ -6,6 +6,7 @@
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/input_event_mouse_button.hpp>
 #include "core/systems/alert/layout/alert_layout_change.h"
+#include "commons/string_helper.h"
 
 void ContainerBox::_ready(){
     set_process(true);
@@ -30,10 +31,70 @@ void ContainerBox::_gui_input(const Ref<InputEvent> &p_gui_input)
     if(auto* mouse_event = Object::cast_to<InputEventMouseButton>(*p_gui_input)){
         if(mouse_event->is_pressed()){
             if(mouse_event->get_button_index() == MouseButton::MOUSE_BUTTON_WHEEL_UP){
-
+                
             }
         }
     }
+}
+
+void ContainerBox::draw_ui(){
+    Rect2 rect = Rect2(Vector2(0, 0), get_size());
+    draw_rect(rect, background_color);
+}
+
+double ContainerBox::get_width_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type){
+    if(unit_type == Harmonia::Unit::NOT_SET) return 0;
+
+    Size2 window_size = get_tree()->get_root()->get_visible_rect().size;
+
+    if(parent == nullptr){
+        Size2 window_size = get_tree()->get_root()->get_visible_rect().size;
+        return ContainerUnitConverter::get_width(pair, window_size.x, window_size, unit_type);
+    }
+
+    return ContainerUnitConverter::get_width(pair, parent->get_width(), window_size, unit_type);
+}
+
+double ContainerBox::get_height_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type){
+    if(unit_type == Harmonia::Unit::NOT_SET) return 0;
+
+    Size2 window_size = get_tree()->get_root()->get_visible_rect().size;
+
+    if(parent == nullptr){
+        Size2 window_size = get_tree()->get_root()->get_visible_rect().size;
+        return ContainerUnitConverter::get_height(pair, window_size.y, window_size, unit_type);
+    }
+
+    return ContainerUnitConverter::get_height(pair, parent->get_height(), window_size, unit_type);
+}
+
+double ContainerBox::editor_get_width_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type){
+    if(unit_type == Harmonia::Unit::NOT_SET) return 0;
+
+    Size2 window_size = Size2(
+        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_width"), 
+        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_height"));
+
+    if(parent == nullptr){
+        return ContainerUnitConverter::get_width(pair, window_size.x, window_size, unit_type);
+    }
+
+    return ContainerUnitConverter::get_width(pair, parent->editor_get_width(), window_size, unit_type);
+
+}
+
+double ContainerBox::editor_get_height_length_pair_unit(LengthPair pair, Harmonia::Unit unit_type){
+    if(unit_type == Harmonia::Unit::NOT_SET) return 0;
+
+    Size2 window_size = Size2(
+        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_width"), 
+        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_height"));
+
+    if(parent == nullptr){
+        return ContainerUnitConverter::get_height(pair, window_size.y, window_size, unit_type);
+    }
+
+    return ContainerUnitConverter::get_height(pair, parent->editor_get_height(), window_size, unit_type);
 }
 
 AlertManager* ContainerBox::get_alert_manager(){
@@ -57,20 +118,24 @@ void ContainerBox::update_presentation(){
 
 void ContainerBox::update_children_position(TypedArray<Node> children){
     Vector2 position = Vector2(0, 0);
-    // Add margin, padding - Future update.
+    // Add padding - Future update.
     
     for (size_t i = 0; i < children.size(); i++)
     {
         auto current_child = children[i];
         if(auto* container = Object::cast_to<ContainerBox>(current_child)){
             if(container->position_type == Position::STATIC){
-                container->set_position(position);
+                position.y += container->get_margin_up();                
+                container->set_position(Vector2(position.x + container->get_margin_left(), position.y));
                 position.y += container->get_height();
+                position.y += container->get_margin_down();
             }else if(container->position_type == Position::ABSOLUTE){
                 container->set_position(Vector2(container->get_pos_x(), container->get_pos_y()));
             }else if(container-> position_type == Position::RELATIVE){
-                container->set_position(Vector2(position.x + container->get_pos_x(), position.y + container->get_pos_y()));
+                position.y += container->get_margin_up();                
+                container->set_position(Vector2(position.x + container->get_margin_left() + container->get_pos_x(), position.y + container->get_pos_y()));
                 position.y += container->editor_get_height();
+                position.y += container->get_margin_down();
             }
         }else if(auto* control = Object::cast_to<Control>(current_child)){
             control->set_position(position);
@@ -93,20 +158,25 @@ void ContainerBox::editor_update_presentation(){
 void ContainerBox::editor_update_children_position(TypedArray<Node> children)
 {
     Vector2 position = Vector2(0, 0);
-    // Add margin, padding - Future update.
-    
+
+    // Add padding - Future update.
     for (size_t i = 0; i < children.size(); i++)
     {
         auto current_child = children[i];
         if(auto* container = Object::cast_to<ContainerBox>(current_child)){
             if(container->position_type == Position::STATIC){
-                container->set_position(position);
+                position.y += container->editor_get_margin_up();
+                container->set_position(Vector2(position.x + container->editor_get_margin_left(), position.y));
                 position.y += container->editor_get_height();
+                position.y += container->editor_get_margin_down();
             }else if(container->position_type == Position::ABSOLUTE){
                 container->set_position(Vector2(container->editor_get_pos_x(), container->editor_get_pos_y()));
             }else if(container-> position_type == Position::RELATIVE){
-                container->set_position(Vector2(position.x + container->editor_get_pos_x(), position.y + container->editor_get_pos_y()));
+                position.y += container->editor_get_margin_up();
+                container->set_position(Vector2(position.x + container->editor_get_margin_left() + container->editor_get_pos_x(), 
+                                        position.y + container->editor_get_pos_y()));
                 position.y += container->editor_get_height();
+                position.y += container->editor_get_margin_down();
             }
         }else if(auto* control = Object::cast_to<Control>(current_child)){
             control->set_position(position);
@@ -126,6 +196,156 @@ ContainerBox* ContainerBox::get_parent_container()
     return nullptr;
 }
 
+void ContainerBox::set_margin_str(String new_margin){
+    List<String> margins = split(new_margin, " ", true);
+    int margin_size = margins.size();
+    margin_str = new_margin;
+    if(margin_size == 1){
+        LengthPair margin_all = LengthPair::get_pair(new_margin);
+        set_margin_all(margin_all.length, margin_all.unit_type);
+        if(debug_outputs) UtilityFunctions::print("Extracted 1 margin:", margin_all.length);
+    }
+    if(margin_size == 2){
+        LengthPair margin_y = LengthPair::get_pair(margins[0]);
+        LengthPair margin_x = LengthPair::get_pair(margins[1]);
+        set_margin_y_vertical(margin_y.length, margin_y.unit_type, false); // false to avoid duplicate alert.
+        set_margin_x_horizontal(margin_x.length, margin_x.unit_type);
+        if(debug_outputs) UtilityFunctions::print("Extracted 2 margins:", margin_y.length, margin_x.length);
+    }
+    if(margin_size == 3){
+        margin_up = LengthPair::get_pair(margins[0]);
+        LengthPair margin_x = LengthPair::get_pair(margins[1]);
+        margin_down = LengthPair::get_pair(margins[2]);
+        set_margin_x_horizontal(margin_x.length, margin_x.unit_type);
+        if(debug_outputs) UtilityFunctions::print("Extracted 3 margins:", margin_up.length, margin_x.length, margin_down.length);
+    }
+    if(margin_size == 4){
+        margin_up = LengthPair::get_pair(margins[0]);
+        margin_right = LengthPair::get_pair(margins[1]);
+        margin_down = LengthPair::get_pair(margins[2]);
+        margin_left = LengthPair::get_pair(margins[3]);
+        if(debug_outputs) UtilityFunctions::print("Extracted 4 margins:", margin_up.length, margin_right.length, margin_down.length, margin_left.length);
+    }
+    else{
+        if(debug_outputs) UtilityFunctions::print("Wrong margin str, couldnt extract any margins");
+    }
+}
+
+String ContainerBox::get_margin_str(){
+    return margin_str;
+}
+
+void ContainerBox::set_margin_all(double all_sides, Harmonia::Unit unit_type, bool dispatch_alert){
+    margin_up.length = all_sides;
+    margin_up.unit_type = unit_type;
+    margin_right.length = all_sides;
+    margin_right.unit_type = unit_type;
+    margin_down.length = all_sides;
+    margin_down.unit_type = unit_type;
+    margin_left.length = all_sides;
+    margin_left.unit_type = unit_type;
+    if (dispatch_alert) alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
+}
+
+void ContainerBox::set_margin_y_vertical(double vertical_y, Harmonia::Unit vertical_unit, bool dispatch_alert){
+    margin_up.length = vertical_y;
+    margin_up.unit_type = vertical_unit;
+    margin_down.length = vertical_y;
+    margin_down.unit_type = vertical_unit;
+    if (dispatch_alert) alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
+}
+
+void ContainerBox::set_margin_x_horizontal(double horizontal_x, Harmonia::Unit horizontal_unit, bool dispatch_alert){
+    margin_right.length = horizontal_x;
+    margin_right.unit_type = horizontal_unit;
+    margin_left.length = horizontal_x;
+    margin_left.unit_type = horizontal_unit;
+    if (dispatch_alert) alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
+}
+
+TypedArray<double> ContainerBox::get_margins(Harmonia::Unit unit_type){
+    // up right down left
+    TypedArray<double> margins;
+    margins[0] = get_margin_up(unit_type);
+    margins[1] = get_margin_right(unit_type);
+    margins[2] = get_margin_down(unit_type);
+    margins[3] = get_margin_left(unit_type);
+    return margins;
+}
+
+TypedArray<double> ContainerBox::editor_get_margins(Harmonia::Unit unit_type){
+    TypedArray<double> margins;
+    margins[0] = editor_get_margin_up(unit_type);
+    margins[1] = editor_get_margin_right(unit_type);
+    margins[2] = editor_get_margin_down(unit_type);
+    margins[3] = editor_get_margin_left(unit_type);
+    return margins;
+}
+
+void ContainerBox::set_margin_up(double up, Harmonia::Unit up_unit, bool dispatch_alert){
+    margin_up.length = up;
+    margin_up.unit_type = up_unit;
+    if (dispatch_alert) alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
+}
+
+double ContainerBox::get_margin_up(Harmonia::Unit unit_type){
+    return get_height_length_pair_unit(margin_up, unit_type);
+}
+
+double ContainerBox::editor_get_margin_up(Harmonia::Unit unit_type){
+    return editor_get_height_length_pair_unit(margin_up, unit_type);
+}
+
+void ContainerBox::set_margin_down(double down, Harmonia::Unit down_unit, bool dispatch_alert){
+    margin_down.length = down;
+    margin_down.unit_type = down_unit;
+    if (dispatch_alert) alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
+}
+
+double ContainerBox::get_margin_down(Harmonia::Unit unit_type){
+    return get_height_length_pair_unit(margin_down, unit_type);
+}
+
+double ContainerBox::editor_get_margin_down(Harmonia::Unit unit_type){
+    return editor_get_height_length_pair_unit(margin_down, unit_type);
+}
+
+void ContainerBox::set_margin_left(double left, Harmonia::Unit left_unit, bool dispatch_alert){
+    margin_left.length = left;
+    margin_left.unit_type = left_unit;
+    if (dispatch_alert) alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));
+}
+double ContainerBox::get_margin_left(Harmonia::Unit unit_type){
+    return get_width_length_pair_unit(margin_left, unit_type);
+}
+
+double ContainerBox::editor_get_margin_left(Harmonia::Unit unit_type){
+    return editor_get_width_length_pair_unit(margin_left, unit_type);
+}
+
+void ContainerBox::set_margin_right(double right, Harmonia::Unit right_unit, bool dispatch_alert){
+    margin_right.length = right;
+    margin_right.unit_type = right_unit;
+    if (dispatch_alert) alert_manager->dispatch_alert(memnew(AlertLayoutChange(ALERT_LAYOUT_CHANGE, AlertLayoutChange::LayoutChanged::MARGIN)));    
+}
+
+double ContainerBox::get_margin_right(Harmonia::Unit unit_type){
+    return get_width_length_pair_unit(margin_right, unit_type);
+}
+
+double ContainerBox::editor_get_margin_right(Harmonia::Unit unit_type){
+    return editor_get_width_length_pair_unit(margin_right, unit_type);
+}
+
+Color ContainerBox::get_background_color(){
+    return background_color;
+}
+
+void ContainerBox::set_background_color(Color color){
+    background_color = color;
+    queue_redraw();
+}
+
 void ContainerBox::set_position_type(Position new_type){
     position_type = new_type;
 }
@@ -141,32 +361,11 @@ void ContainerBox::set_pos_x(double new_x, Harmonia::Unit unit_type){
 }
 
 double ContainerBox::get_pos_x(Harmonia::Unit unit_type){
-    if(unit_type == Harmonia::Unit::NOT_SET) return 0;
-    if(debug_outputs) UtilityFunctions::print("[RUNTIME] Pos x: ", pos_x.length, " ", pos_x.unit_type);
-
-    Size2 window_size = get_tree()->get_root()->get_visible_rect().size;
-
-    if(parent == nullptr){
-        Size2 window_size = get_tree()->get_root()->get_visible_rect().size;
-        return ContainerUnitConverter::get_width(pos_x, window_size.x, window_size, unit_type);
-    }
-
-    return ContainerUnitConverter::get_width(pos_x, parent->get_width(), window_size, unit_type);
+    return get_width_length_pair_unit(pos_x, unit_type);
 }
 
 double ContainerBox::editor_get_pos_x(Harmonia::Unit unit_type){
-    if(unit_type == Harmonia::Unit::NOT_SET) return 0;
-    if(debug_outputs) UtilityFunctions::print("[EDITOR] Pos x: ", pos_x.length, " ", pos_x.unit_type);
-
-    Size2 window_size = Size2(
-        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_width"), 
-        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_height"));
-
-    if(parent == nullptr){
-        return ContainerUnitConverter::get_width(pos_x, window_size.x, window_size, unit_type);
-    }
-
-    return ContainerUnitConverter::get_width(pos_x, parent->editor_get_width(), window_size, unit_type);
+    return editor_get_width_length_pair_unit(pos_x, unit_type);
 }
 
 void ContainerBox::set_pos_x_str(String new_x){
@@ -186,31 +385,11 @@ void ContainerBox::set_pos_y(double new_y, Harmonia::Unit unit_type){
 }
 
 double ContainerBox::get_pos_y(Harmonia::Unit unit_type){
-    if(unit_type == Harmonia::Unit::NOT_SET) return 0;
-    if(debug_outputs) UtilityFunctions::print("[RUNTIME] Pos y: ", pos_y.length, " ", pos_y.unit_type);
-
-    Size2 window_size = get_tree()->get_root()->get_visible_rect().size;
-
-    if(parent == nullptr){
-        return ContainerUnitConverter::get_height(pos_y, window_size.y, window_size, unit_type);
-    }
-
-    return ContainerUnitConverter::get_height(pos_y, parent->get_height(), window_size, unit_type);
+    return get_height_length_pair_unit(pos_y, unit_type);
 }
 
 double ContainerBox::editor_get_pos_y(Harmonia::Unit unit_type){
-    if(unit_type == Harmonia::Unit::NOT_SET) return 0;
-    if(debug_outputs) UtilityFunctions::print("[EDITOR] Pos y: ", pos_y.length, " ", pos_y.unit_type);
-
-    Size2 window_size = Size2(
-        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_width"), 
-        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_height"));
-
-    if(parent == nullptr){
-        return ContainerUnitConverter::get_width(pos_y, window_size.y, window_size, unit_type);
-    }
-
-    return ContainerUnitConverter::get_width(pos_y, parent->editor_get_height(), window_size, unit_type);
+    return editor_get_height_length_pair_unit(pos_y, unit_type);
 }
 
 void ContainerBox::set_pos_y_str(String new_y){
@@ -234,15 +413,7 @@ bool ContainerBox::get_debug_outputs()
 }
 
 double ContainerBox::get_width(Harmonia::Unit unit_type){
-    if(unit_type == Harmonia::Unit::NOT_SET) return 0;
-    if(debug_outputs) UtilityFunctions::print("[RUNTIME] Width: ", width.length, " ", width.unit_type);
-
-    Size2 window_size = get_tree()->get_root()->get_visible_rect().size;
-    if(parent == nullptr){
-        return ContainerUnitConverter::get_width(width, window_size.x, window_size, unit_type);
-    }
-
-    return ContainerUnitConverter::get_width(width, parent->get_width(), window_size, unit_type);
+    return get_width_length_pair_unit(width, unit_type);
 }
 
 void ContainerBox::set_width(double length, Harmonia::Unit unit_type){
@@ -253,18 +424,7 @@ void ContainerBox::set_width(double length, Harmonia::Unit unit_type){
 
 double ContainerBox::editor_get_width(Harmonia::Unit unit_type)
 {
-    if(unit_type == Harmonia::Unit::NOT_SET) return 0;
-    if(debug_outputs) UtilityFunctions::print("[EDITOR] Width: ", width.length, " ", width.unit_type);
-
-    Size2 window_size = Size2(
-        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_width"), 
-        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_height"));
-
-    if(parent == nullptr){
-        return ContainerUnitConverter::get_width(width, window_size.x, window_size, unit_type);
-    }
-
-    return ContainerUnitConverter::get_width(width, parent->editor_get_width(), window_size, unit_type);
+    return editor_get_width_length_pair_unit(width, unit_type);
 }
 
 void ContainerBox::set_width_str(String length_and_unit){
@@ -296,33 +456,12 @@ String ContainerBox::get_height_str()
 }
 
 double ContainerBox::get_height(Harmonia::Unit unit_type){
-    if(unit_type == Harmonia::Unit::NOT_SET) return 0;
-    if(debug_outputs) UtilityFunctions::print("[RUNTIME] Width: ", width.length, " ", width.unit_type);
-
-    Size2 window_size = get_tree()->get_root()->get_visible_rect().size;
-
-    if(parent == nullptr){
-        Size2 window_size = get_tree()->get_root()->get_visible_rect().size;
-        return ContainerUnitConverter::get_height(height, window_size.y, window_size, unit_type);
-    }
-
-    return ContainerUnitConverter::get_height(height, parent->get_height(), window_size, unit_type);
+    return get_height_length_pair_unit(height, unit_type);
 }
 
 double ContainerBox::editor_get_height(Harmonia::Unit unit_type)
 {    
-    if(unit_type == Harmonia::Unit::NOT_SET) return 0;
-    if(debug_outputs) UtilityFunctions::print("[EDITOR] Height: ", width.length, " ", width.unit_type);
-
-    Size2 window_size = Size2(
-        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_width"), 
-        ProjectSettings::get_singleton()->get_setting("display/window/size/viewport_height"));
-
-    if(parent == nullptr){
-        return ContainerUnitConverter::get_height(height, window_size.y, window_size, unit_type);
-    }
-
-    return ContainerUnitConverter::get_height(height, parent->editor_get_height(), window_size, unit_type);
+    return editor_get_height_length_pair_unit(height, unit_type);
 }
 
 void ContainerBox::_notification(int p_what)
@@ -333,6 +472,8 @@ void ContainerBox::_notification(int p_what)
         _process(get_process_delta_time());
     }else if(p_what == NOTIFICATION_RESIZED){
         // Process to convert new size to current unit size.
+    }else if(p_what == NOTIFICATION_DRAW){
+        draw_ui();
     }
 }
 
@@ -370,8 +511,28 @@ void ContainerBox::_bind_methods(){
     ClassDB::bind_method(D_METHOD("set_pos_y", "new_y", "unit_type"), &ContainerBox::set_pos_y);
     ClassDB::bind_method(D_METHOD("get_pos_y", "unit_type"), &ContainerBox::get_pos_y);
 
-    const String positioning_types = "STATIC:0,ABSOLUTE:1,RELATIVE:2";
+    ClassDB::bind_method(D_METHOD("set_margin_all", "all_sides", "unit_type", "dispatch_alert"), &ContainerBox::set_margin_all, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("set_margin_y_vertical", "vertical_y", "vertical_unit", "dispatch_alert"), &ContainerBox::set_margin_y_vertical, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("set_margin_x_horizontal", "horizontal_x", "horizontal_unit", "dispatch_alert"), &ContainerBox::set_margin_x_horizontal, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("get_margins", "unit_type"), &ContainerBox::get_margins, DEFVAL(Harmonia::PIXEL));
 
+    ClassDB::bind_method(D_METHOD("set_margin_str", "new_margin"), &ContainerBox::set_margin_str);
+    ClassDB::bind_method(D_METHOD("get_margin_str"), &ContainerBox::get_margin_str);
+    ClassDB::bind_method(D_METHOD("set_margin_up", "up_margin", "up_unit", "dispatch_alert"), &ContainerBox::set_margin_up, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("get_margin_up", "unit_type"), &ContainerBox::get_margin_up, DEFVAL(Harmonia::PIXEL));
+    ClassDB::bind_method(D_METHOD("set_margin_right", "right_margin", "right_unit", "dispatch_alert"), &ContainerBox::set_margin_right, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("get_margin_right", "unit_type"), &ContainerBox::get_margin_right, DEFVAL(Harmonia::PIXEL));
+    ClassDB::bind_method(D_METHOD("set_margin_down", "down_margin", "down_unit", "dispatch_alert"), &ContainerBox::set_margin_down, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("get_margin_down", "unit_type"), &ContainerBox::get_margin_down, DEFVAL(Harmonia::PIXEL));
+    ClassDB::bind_method(D_METHOD("set_margin_left", "left_margin", "left_unit", "dispatch_alert"), &ContainerBox::set_margin_left, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("get_margin_left", "unit_type"), &ContainerBox::get_margin_left, DEFVAL(Harmonia::PIXEL));
+    
+    ClassDB::bind_method(D_METHOD("set_background_color", "color"), &ContainerBox::set_background_color);
+    ClassDB::bind_method(D_METHOD("get_background_color"), &ContainerBox::get_background_color);
+
+    ClassDB::bind_method(D_METHOD("update_presentation"), &ContainerBox::update_presentation);
+
+    const String positioning_types = "STATIC:0,ABSOLUTE:1,RELATIVE:2";
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "alert_manager", PROPERTY_HINT_RESOURCE_TYPE, "alert_manager", PROPERTY_USAGE_NO_EDITOR), "set_alert_manager", "get_alert_manager");
     ADD_PROPERTY(PropertyInfo(Variant::STRING, "width_str", PROPERTY_HINT_TYPE_STRING, "width_str", PROPERTY_USAGE_NO_EDITOR), "set_width_str", "get_width_str");
     ADD_PROPERTY(PropertyInfo(Variant::STRING, "height_str", PROPERTY_HINT_TYPE_STRING, "height_str", PROPERTY_USAGE_NO_EDITOR), "set_height_str", "get_height_str");
@@ -379,6 +540,8 @@ void ContainerBox::_bind_methods(){
     ADD_PROPERTY(PropertyInfo(Variant::INT, "positioning", PROPERTY_HINT_ENUM, positioning_types, PROPERTY_USAGE_DEFAULT), "set_position_type", "get_position_type");
     ADD_PROPERTY(PropertyInfo(Variant::STRING, "pos_x_str", PROPERTY_HINT_TYPE_STRING, "pos_x_str", PROPERTY_USAGE_NO_EDITOR), "set_pos_x_str", "get_pos_x_str");
     ADD_PROPERTY(PropertyInfo(Variant::STRING, "pos_y_str", PROPERTY_HINT_TYPE_STRING, "pos_y_str", PROPERTY_USAGE_NO_EDITOR), "set_pos_y_str", "get_pos_y_str");
+    ADD_PROPERTY(PropertyInfo(Variant::STRING, "margin_str", PROPERTY_HINT_TYPE_STRING, "margin_str", PROPERTY_USAGE_NO_EDITOR), "set_margin_str", "get_margin_str");
+    ADD_PROPERTY(PropertyInfo(Variant::COLOR, "background_color", PROPERTY_HINT_NONE, "background_color", PROPERTY_USAGE_NO_EDITOR), "set_background_color", "get_background_color");
 }
 
 bool ContainerBox::_set(const StringName &p_name, const Variant &p_value)
@@ -390,7 +553,14 @@ bool ContainerBox::_set(const StringName &p_name, const Variant &p_value)
 	}else if(name == "height_str"){
         set_height_str(p_value);
         return true;
-    }else if(name == "debug_outputs"){
+    }else if(name == "margin_str"){
+        set_margin_str(p_value);
+        return true;
+    }else if(name == "background_color"){
+        set_background_color(p_value);
+        return true;
+    }
+    else if(name == "debug_outputs"){
         set_debug_outputs(p_value);
     	return true;
     }else if(name == "pos_x_str"){
@@ -412,6 +582,12 @@ bool ContainerBox::_get(const StringName &p_name, Variant &r_ret) const
 	}else if(name == "height_str"){
         r_ret = height_str;
         return true;
+    }else if(name == "margin_str"){
+        r_ret = margin_str;
+        return true;   
+    }else if(name == "background_color"){
+        r_ret = background_color;
+        return true;
     }else if(name == "debug_outputs"){
         r_ret = debug_outputs;
     	return true;
@@ -429,6 +605,8 @@ void ContainerBox::_get_property_list(List<PropertyInfo> *p_list) const
 {
     p_list->push_back(PropertyInfo(Variant::STRING, "width_str"));
     p_list->push_back(PropertyInfo(Variant::STRING, "height_str"));
+    p_list->push_back(PropertyInfo(Variant::STRING, "margin_str"));
+    p_list->push_back(PropertyInfo(Variant::COLOR, "background_color"));
     p_list->push_back(PropertyInfo(Variant::BOOL, "debug_outputs"));
     p_list->push_back(PropertyInfo(Variant::STRING, "pos_x_str"));
     p_list->push_back(PropertyInfo(Variant::STRING, "pos_y_str"));

--- a/src/core/systems/alert/layout/alert_layout_change.cpp
+++ b/src/core/systems/alert/layout/alert_layout_change.cpp
@@ -5,3 +5,12 @@ AlertLayoutChange::AlertLayoutChange(String name, LayoutChanged changed)
     alert_name = name;
     layout_changed = changed;
 }
+
+void AlertLayoutChange::_bind_methods()
+{
+    BIND_ENUM_CONSTANT(AlertLayoutChange::WIDTH);
+    BIND_ENUM_CONSTANT(AlertLayoutChange::HEIGHT);
+    BIND_ENUM_CONSTANT(AlertLayoutChange::POSITION);
+    BIND_ENUM_CONSTANT(AlertLayoutChange::MARGIN);
+    BIND_ENUM_CONSTANT(AlertLayoutChange::PADDING);
+}

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -6,6 +6,7 @@
 #include "containers/container_box.h"
 #include "commons/unit_converter.h"
 #include "core/systems/alert/alert.h"
+#include "core/systems/alert/layout/alert_layout_change.h"
 #include "core/systems/alert/alert_manager.h"
 
 using namespace godot;
@@ -17,6 +18,7 @@ void initialize_harmonia(ModuleInitializationLevel p_level) {
 
 	GDREGISTER_CLASS(Harmonia);
 	GDREGISTER_VIRTUAL_CLASS(Alert);
+	GDREGISTER_CLASS(AlertLayoutChange);
 	GDREGISTER_CLASS(AlertManager);
 	GDREGISTER_CLASS(ContainerBox);
 }


### PR DESCRIPTION
* Margins, backgrounds, split, and bugfixes

Adds margins up right down left.
 - Note: for this specific container the right margin is not used, this is because the base container flow makes it unnecessary, however the right margin will be used in different container types.

Added LayoutChanged values into enum for Margin and padding (will be added later).

Adds background color possibility using draw notifications and canvas item draw functions. Adds split function into string helper file.

Fixes replace function in string helper file, where previously the function would run in a loop to decrease the index, now the index value is simply added into iterator

Fixes length pair and other variables without default value, now replaced with default initialization value of 0. Before fix this caused the unset values like positions/sizes and other to have unwanted garbage values where really 0 was wanted.

* Documentations and minor fixes.

Added documentation and small features or fixes.

* Additional functions open to API

Added setters and getters function to the script API. Fixed problem with AlertLayoutChange being not registered