### PR TITLE
Removed unintended ContainerBox behavior

### DIFF
--- a/extensions/csharp/containers/ContainerBox.cs
+++ b/extensions/csharp/containers/ContainerBox.cs
@@ -12,7 +12,6 @@ namespace HarmoniaUI.containers
     /// Represents a UI container that manages layout, positioning, paddings, margins, and other related properties.
     /// Provides methods for handling visibility, event binding, layout management.
     /// </summary>
-    [GlobalClass]
     public partial class ContainerBox : Control
     {
         public ContainerBox() {


### PR DESCRIPTION
Removed GlobalClass from ContainerBox which led Godot to pick the .cs class over the extension class which hid the extension class exported variables.